### PR TITLE
Move haxelib.json up to the root dir to make it installable via git

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -1,6 +1,7 @@
 {
   "name": "stb_ogg_sound",
   "url" : "https://github.com/shohei909/haxe_stb_ogg_sound",
+  "classPath": "src/",
   "license": "Public",
   "tags": ["flash", "cs", "java", "neko", "ogg", "format"],
   "description": "public domain ogg decoder",


### PR DESCRIPTION
This change moves `haxelib.json` to a place where haxelib can find it when installing from git.